### PR TITLE
Improved Editor Workflow for Scripts (And More)

### DIFF
--- a/Engine-Editor/GameProject/Assets/Scenes/ScriptRefactor.scene
+++ b/Engine-Editor/GameProject/Assets/Scenes/ScriptRefactor.scene
@@ -1,85 +1,41 @@
 Scene: ScriptRefactor.scene
 Entities:
-  - Entity: 6453289136765797799
+  - Entity: 4439650569278229468
     TagComponent:
-      Tag: VariableValidator
+      Tag: Camera
     TransformComponent:
       Position: [0, 0, 0]
       Rotation: [0, 0, 0]
       Scale: [1, 1, 1]
+    CameraComponent:
+      Camera:
+        ProjectionType: Perspective
+        PerspectiveFOV: 0.785398185
+        PerspectiveNear: 0.00999999978
+        PerspectiveFar: 1000
+        OrthographicSize: 10
+        OrthographicNear: -1
+        OrthographicFar: 10
+      Primary: true
+      FixedAspectRatio: false
     ScriptComponent:
-      ClassName: GameProject.Source.VariableValidator
+      ClassName: GameProject.Source.Camera
       ScriptFields:
-        - Name: Var13
-          Type: Vector2
-          Data: [18.8999996, 13.3999996]
-        - Name: Var0
-          Type: Bool
-          Data: true
-        - Name: Var12
-          Type: ULong
-          Data: 1498
-        - Name: Var1
-          Type: Char
-          Data: H
-        - Name: Var11
-          Type: Long
-          Data: 1614
-        - Name: Var2
-          Type: String
-          Data: asdf
-        - Name: Var10
-          Type: UInt
-          Data: 2226
-        - Name: Var3
+        - Name: DistanceFromPlayerMax
           Type: Float
-          Data: 14.5
-        - Name: Var4
-          Type: Double
-          Data: 30.700001
-        - Name: Var5
-          Type: SByte
-          Data: 127
-        - Name: Var15
-          Type: Vector4
-          Data: [5.0999999, 12.6999998, 10, 8.69999981]
-        - Name: Var6
-          Type: Byte
-          Data: 102
-        - Name: Var14
-          Type: Vector3
-          Data: [-5.4000001, -4.80000019, -4.9000001]
-        - Name: Var7
-          Type: Short
-          Data: 127
-        - Name: Var8
-          Type: UShort
-          Data: 241
-        - Name: Var9
-          Type: Int
-          Data: -192
-  - Entity: 17908196038695326210
-    TagComponent:
-      Tag: Ground
-    TransformComponent:
-      Position: [-3.06509781, -1.70000005, 0]
-      Rotation: [0, 0, 0]
-      Scale: [15, 0.5, 1]
-    SpriteRendererComponent:
-      Color: [0, 0.421940923, 0.416917831, 1]
-      Path: ""
-      Tiling: 1
-    Rigidbody2DComponent:
-      Type: Static
-      FixedRotation: false
-      Smoothing: Interpolation
-    BoxCollider2DComponent:
-      Offset: [0, 0]
-      Size: [0.5, 0.5]
-      Density: 1
-      Friction: 0.5
-      Restitution: 0
-      RestitutionThreshold: 0.5
+          Data: 50
+        - Name: DistanceFromPlayer
+          Type: Float
+          Data: 0
+        - Name: DistanceFromPlayerMin
+          Type: Float
+          Data: 8
+        - Name: offSet
+          Type: Vector2
+          Data: [0, 2]
+        - Name: zoomSpeedPercentIncrease
+          Type: Float
+          Data: 0.5
   - Entity: 11764441337374806066
     TagComponent:
       Tag: Player
@@ -117,39 +73,83 @@ Entities:
       Friction: 0.5
       Restitution: 0
       RestitutionThreshold: 0.5
-  - Entity: 4439650569278229468
+  - Entity: 17908196038695326210
     TagComponent:
-      Tag: Camera
+      Tag: Ground
+    TransformComponent:
+      Position: [-3.06509781, -1.70000005, 0]
+      Rotation: [0, 0, 0]
+      Scale: [15, 0.5, 1]
+    SpriteRendererComponent:
+      Color: [0, 0.421940923, 0.416917831, 1]
+      Path: ""
+      Tiling: 1
+    Rigidbody2DComponent:
+      Type: Static
+      FixedRotation: false
+      Smoothing: Interpolation
+    BoxCollider2DComponent:
+      Offset: [0, 0]
+      Size: [0.5, 0.5]
+      Density: 1
+      Friction: 0.5
+      Restitution: 0
+      RestitutionThreshold: 0.5
+  - Entity: 6453289136765797799
+    TagComponent:
+      Tag: VariableValidator
     TransformComponent:
       Position: [0, 0, 0]
       Rotation: [0, 0, 0]
       Scale: [1, 1, 1]
-    CameraComponent:
-      Camera:
-        ProjectionType: Perspective
-        PerspectiveFOV: 0.785398185
-        PerspectiveNear: 0.00999999978
-        PerspectiveFar: 1000
-        OrthographicSize: 10
-        OrthographicNear: -1
-        OrthographicFar: 10
-      Primary: true
-      FixedAspectRatio: false
     ScriptComponent:
-      ClassName: GameProject.Source.Camera
+      ClassName: GameProject.Source.VariableValidator
       ScriptFields:
-        - Name: DistanceFromPlayerMax
-          Type: Float
-          Data: 50
-        - Name: DistanceFromPlayer
-          Type: Float
-          Data: 0
-        - Name: DistanceFromPlayerMin
-          Type: Float
-          Data: 8
-        - Name: offSet
+        - Name: Var13
           Type: Vector2
-          Data: [0, 2]
-        - Name: zoomSpeedPercentIncrease
+          Data: [18.8999996, 13.3999996]
+        - Name: Var0
+          Type: Bool
+          Data: true
+        - Name: Var12
+          Type: ULong
+          Data: 1498
+        - Name: Var1
+          Type: Char
+          Data: y
+        - Name: Var11
+          Type: Long
+          Data: 1614
+        - Name: Var2
+          Type: String
+          Data: asdf
+        - Name: Var10
+          Type: UInt
+          Data: 2226
+        - Name: Var3
           Type: Float
-          Data: 0.5
+          Data: 14.5
+        - Name: Var4
+          Type: Double
+          Data: 30.700001
+        - Name: Var5
+          Type: SByte
+          Data: 127
+        - Name: Var15
+          Type: Vector4
+          Data: [5.0999999, 12.6999998, 10, 8.69999981]
+        - Name: Var6
+          Type: Byte
+          Data: 102
+        - Name: Var14
+          Type: Vector3
+          Data: [-5.4000001, -4.80000019, -4.9000001]
+        - Name: Var7
+          Type: Short
+          Data: 127
+        - Name: Var8
+          Type: UShort
+          Data: 241
+        - Name: Var9
+          Type: Int
+          Data: -192

--- a/Engine-Editor/GameProject/Assets/Scenes/ScriptRefactor.scene
+++ b/Engine-Editor/GameProject/Assets/Scenes/ScriptRefactor.scene
@@ -1,27 +1,41 @@
 Scene: ScriptRefactor.scene
 Entities:
-  - Entity: 17908196038695326210
+  - Entity: 4439650569278229468
     TagComponent:
-      Tag: Ground
+      Tag: Camera
     TransformComponent:
-      Position: [-3.06509781, -1.70000005, 0]
+      Position: [0, 0, 0]
       Rotation: [0, 0, 0]
-      Scale: [15, 0.5, 1]
-    SpriteRendererComponent:
-      Color: [0, 0.421940923, 0.416917831, 1]
-      Path: ""
-      Tiling: 1
-    Rigidbody2DComponent:
-      Type: Static
-      FixedRotation: false
-      Smoothing: Interpolation
-    BoxCollider2DComponent:
-      Offset: [0, 0]
-      Size: [0.5, 0.5]
-      Density: 1
-      Friction: 0.5
-      Restitution: 0
-      RestitutionThreshold: 0.5
+      Scale: [1, 1, 1]
+    CameraComponent:
+      Camera:
+        ProjectionType: Perspective
+        PerspectiveFOV: 0.785398185
+        PerspectiveNear: 0.00999999978
+        PerspectiveFar: 1000
+        OrthographicSize: 10
+        OrthographicNear: -1
+        OrthographicFar: 10
+      Primary: true
+      FixedAspectRatio: false
+    ScriptComponent:
+      ClassName: GameProject.Source.Camera
+      ScriptFields:
+        - Name: DistanceFromPlayerMax
+          Type: Float
+          Data: 50
+        - Name: DistanceFromPlayer
+          Type: Float
+          Data: 0
+        - Name: DistanceFromPlayerMin
+          Type: Float
+          Data: 8
+        - Name: offSet
+          Type: Vector2
+          Data: [0, 2]
+        - Name: zoomSpeedPercentIncrease
+          Type: Float
+          Data: 0.5
   - Entity: 11764441337374806066
     TagComponent:
       Tag: Player
@@ -45,9 +59,6 @@ Entities:
         - Name: movement
           Type: Vector2
           Data: [0, 0]
-        - Name: zoomSpeed
-          Type: Float
-          Data: 2
         - Name: exampleString
           Type: String
           Data: Chicken
@@ -62,27 +73,25 @@ Entities:
       Friction: 0.5
       Restitution: 0
       RestitutionThreshold: 0.5
-  - Entity: 4439650569278229468
+  - Entity: 17908196038695326210
     TagComponent:
-      Tag: Camera
+      Tag: Ground
     TransformComponent:
-      Position: [0, 0, 0]
+      Position: [-3.06509781, -1.70000005, 0]
       Rotation: [0, 0, 0]
-      Scale: [1, 1, 1]
-    CameraComponent:
-      Camera:
-        ProjectionType: Perspective
-        PerspectiveFOV: 0.785398185
-        PerspectiveNear: 0.00999999978
-        PerspectiveFar: 1000
-        OrthographicSize: 10
-        OrthographicNear: -1
-        OrthographicFar: 10
-      Primary: true
-      FixedAspectRatio: false
-    ScriptComponent:
-      ClassName: GameProject.Source.Camera
-      ScriptFields:
-        - Name: DistanceFromPlayer
-          Type: Float
-          Data: 5
+      Scale: [15, 0.5, 1]
+    SpriteRendererComponent:
+      Color: [0, 0.421940923, 0.416917831, 1]
+      Path: ""
+      Tiling: 1
+    Rigidbody2DComponent:
+      Type: Static
+      FixedRotation: false
+      Smoothing: Interpolation
+    BoxCollider2DComponent:
+      Offset: [0, 0]
+      Size: [0.5, 0.5]
+      Density: 1
+      Friction: 0.5
+      Restitution: 0
+      RestitutionThreshold: 0.5

--- a/Engine-Editor/GameProject/Assets/Scenes/ScriptRefactor.scene
+++ b/Engine-Editor/GameProject/Assets/Scenes/ScriptRefactor.scene
@@ -1,100 +1,63 @@
 Scene: ScriptRefactor.scene
 Entities:
-  - Entity: 4439650569278229468
+  - Entity: 13451980592939124771
     TagComponent:
-      Tag: Camera
+      Tag: Entity
     TransformComponent:
       Position: [0, 0, 0]
       Rotation: [0, 0, 0]
       Scale: [1, 1, 1]
-    CameraComponent:
-      Camera:
-        ProjectionType: Perspective
-        PerspectiveFOV: 0.785398185
-        PerspectiveNear: 0.00999999978
-        PerspectiveFar: 1000
-        OrthographicSize: 10
-        OrthographicNear: -1
-        OrthographicFar: 10
-      Primary: true
-      FixedAspectRatio: false
     ScriptComponent:
-      ClassName: GameProject.Source.Camera
+      ClassName: GameProject.Source.VariableValidator
       ScriptFields:
-        - Name: DistanceFromPlayerMax
-          Type: Float
-          Data: 50
-        - Name: DistanceFromPlayer
-          Type: Float
-          Data: 0
-        - Name: DistanceFromPlayerMin
-          Type: Float
-          Data: 8
-        - Name: offSet
+        - Name: Var13
           Type: Vector2
-          Data: [0, 2]
-        - Name: zoomSpeedPercentIncrease
-          Type: Float
-          Data: 0.5
-  - Entity: 11764441337374806066
-    TagComponent:
-      Tag: Player
-    TransformComponent:
-      Position: [0, 0, 0]
-      Rotation: [0, 0, 0]
-      Scale: [1, 1, 1]
-    SpriteRendererComponent:
-      Color: [0, 1, 0.607594967, 1]
-      Path: Textures\shipGreen_manned.png
-      Tiling: 1
-    ScriptComponent:
-      ClassName: GameProject.Source.Player
-      ScriptFields:
-        - Name: moveSpeed
-          Type: Float
-          Data: 50
-        - Name: rotSpeeed
-          Type: Float
-          Data: 2.20000005
-        - Name: movement
-          Type: Vector2
-          Data: [0, 0]
-        - Name: exampleString
+          Data: [1234, -1234]
+        - Name: Var0
+          Type: Bool
+          Data: true
+        - Name: Var12
+          Type: ULong
+          Data: 6316545
+        - Name: Var1
+          Type: Char
+          Data: Y
+        - Name: Var11
+          Type: Long
+          Data: -3165
+        - Name: Var2
           Type: String
-          Data: Chicken
-    Rigidbody2DComponent:
-      Type: Dynamic
-      FixedRotation: false
-      Smoothing: Interpolation
-    BoxCollider2DComponent:
-      Offset: [0, 0]
-      Size: [0.5, 0.5]
-      Density: 1
-      Friction: 0.5
-      Restitution: 0
-      RestitutionThreshold: 0.5
-  - Entity: 17908196038695326210
-    TagComponent:
-      Tag: Ground
-    TransformComponent:
-      Position: [-3.06509781, -1.70000005, 0]
-      Rotation: [0, 0, 0]
-      Scale: [15, 0.5, 1]
-    SpriteRendererComponent:
-      Color: [0, 0.421940923, 0.416917831, 1]
-      Path: ""
-      Tiling: 1
-    Rigidbody2DComponent:
-      Type: Static
-      FixedRotation: false
-      Smoothing: Interpolation
-    BoxCollider2DComponent:
-      Offset: [0, 0]
-      Size: [0.5, 0.5]
-      Density: 1
-      Friction: 0.5
-      Restitution: 0
-      RestitutionThreshold: 0.5
+          Data: Hello There!
+        - Name: Var10
+          Type: UInt
+          Data: 31654
+        - Name: Var3
+          Type: Float
+          Data: 192.123001
+        - Name: Var4
+          Type: Double
+          Data: 1237.1231689453125
+        - Name: Var5
+          Type: SByte
+          Data: -96
+        - Name: Var15
+          Type: Vector4
+          Data: [1234, 1234, -98723, 12356]
+        - Name: Var6
+          Type: Byte
+          Data: 240
+        - Name: Var14
+          Type: Vector3
+          Data: [-1234, 1234, 98723]
+        - Name: Var7
+          Type: Short
+          Data: -2400
+        - Name: Var8
+          Type: UShort
+          Data: 2400
+        - Name: Var9
+          Type: Int
+          Data: -21654
   - Entity: 6453289136765797799
     TagComponent:
       Tag: VariableValidator
@@ -153,3 +116,98 @@ Entities:
         - Name: Var9
           Type: Int
           Data: -192
+  - Entity: 17908196038695326210
+    TagComponent:
+      Tag: Ground
+    TransformComponent:
+      Position: [-3.06509781, -1.70000005, 0]
+      Rotation: [0, 0, 0]
+      Scale: [15, 0.5, 1]
+    SpriteRendererComponent:
+      Color: [0, 0.421940923, 0.416917831, 1]
+      Path: ""
+      Tiling: 1
+    Rigidbody2DComponent:
+      Type: Static
+      FixedRotation: false
+      Smoothing: Interpolation
+    BoxCollider2DComponent:
+      Offset: [0, 0]
+      Size: [0.5, 0.5]
+      Density: 1
+      Friction: 0.5
+      Restitution: 0
+      RestitutionThreshold: 0.5
+  - Entity: 11764441337374806066
+    TagComponent:
+      Tag: Player
+    TransformComponent:
+      Position: [0, 0, 0]
+      Rotation: [0, 0, 0]
+      Scale: [1, 1, 1]
+    SpriteRendererComponent:
+      Color: [0, 1, 0.607594967, 1]
+      Path: Textures\shipGreen_manned.png
+      Tiling: 1
+    ScriptComponent:
+      ClassName: GameProject.Source.Player
+      ScriptFields:
+        - Name: moveSpeed
+          Type: Float
+          Data: 50
+        - Name: rotSpeeed
+          Type: Float
+          Data: 2.20000005
+        - Name: movement
+          Type: Vector2
+          Data: [0, 0]
+        - Name: exampleString
+          Type: String
+          Data: Chicken
+    Rigidbody2DComponent:
+      Type: Dynamic
+      FixedRotation: false
+      Smoothing: Interpolation
+    BoxCollider2DComponent:
+      Offset: [0, 0]
+      Size: [0.5, 0.5]
+      Density: 1
+      Friction: 0.5
+      Restitution: 0
+      RestitutionThreshold: 0.5
+  - Entity: 4439650569278229468
+    TagComponent:
+      Tag: Camera
+    TransformComponent:
+      Position: [0, 0, 0]
+      Rotation: [0, 0, 0]
+      Scale: [1, 1, 1]
+    CameraComponent:
+      Camera:
+        ProjectionType: Perspective
+        PerspectiveFOV: 0.785398185
+        PerspectiveNear: 0.00999999978
+        PerspectiveFar: 1000
+        OrthographicSize: 10
+        OrthographicNear: -1
+        OrthographicFar: 10
+      Primary: true
+      FixedAspectRatio: false
+    ScriptComponent:
+      ClassName: GameProject.Source.Camera
+      ScriptFields:
+        - Name: DistanceFromPlayerMax
+          Type: Float
+          Data: 50
+        - Name: DistanceFromPlayer
+          Type: Float
+          Data: 0
+        - Name: DistanceFromPlayerMin
+          Type: Float
+          Data: 8
+        - Name: offSet
+          Type: Vector2
+          Data: [0, 2]
+        - Name: zoomSpeedPercentIncrease
+          Type: Float
+          Data: 0.5

--- a/Engine-Editor/GameProject/Assets/Scenes/ScriptRefactor.scene
+++ b/Engine-Editor/GameProject/Assets/Scenes/ScriptRefactor.scene
@@ -1,41 +1,85 @@
 Scene: ScriptRefactor.scene
 Entities:
-  - Entity: 4439650569278229468
+  - Entity: 6453289136765797799
     TagComponent:
-      Tag: Camera
+      Tag: VariableValidator
     TransformComponent:
       Position: [0, 0, 0]
       Rotation: [0, 0, 0]
       Scale: [1, 1, 1]
-    CameraComponent:
-      Camera:
-        ProjectionType: Perspective
-        PerspectiveFOV: 0.785398185
-        PerspectiveNear: 0.00999999978
-        PerspectiveFar: 1000
-        OrthographicSize: 10
-        OrthographicNear: -1
-        OrthographicFar: 10
-      Primary: true
-      FixedAspectRatio: false
     ScriptComponent:
-      ClassName: GameProject.Source.Camera
+      ClassName: GameProject.Source.VariableValidator
       ScriptFields:
-        - Name: DistanceFromPlayerMax
-          Type: Float
-          Data: 50
-        - Name: DistanceFromPlayer
-          Type: Float
-          Data: 0
-        - Name: DistanceFromPlayerMin
-          Type: Float
-          Data: 8
-        - Name: offSet
+        - Name: Var13
           Type: Vector2
-          Data: [0, 2]
-        - Name: zoomSpeedPercentIncrease
+          Data: [18.8999996, 13.3999996]
+        - Name: Var0
+          Type: Bool
+          Data: true
+        - Name: Var12
+          Type: ULong
+          Data: 1498
+        - Name: Var1
+          Type: Char
+          Data: H
+        - Name: Var11
+          Type: Long
+          Data: 1614
+        - Name: Var2
+          Type: String
+          Data: asdf
+        - Name: Var10
+          Type: UInt
+          Data: 2226
+        - Name: Var3
           Type: Float
-          Data: 0.5
+          Data: 14.5
+        - Name: Var4
+          Type: Double
+          Data: 30.700001
+        - Name: Var5
+          Type: SByte
+          Data: 127
+        - Name: Var15
+          Type: Vector4
+          Data: [5.0999999, 12.6999998, 10, 8.69999981]
+        - Name: Var6
+          Type: Byte
+          Data: 102
+        - Name: Var14
+          Type: Vector3
+          Data: [-5.4000001, -4.80000019, -4.9000001]
+        - Name: Var7
+          Type: Short
+          Data: 127
+        - Name: Var8
+          Type: UShort
+          Data: 241
+        - Name: Var9
+          Type: Int
+          Data: -192
+  - Entity: 17908196038695326210
+    TagComponent:
+      Tag: Ground
+    TransformComponent:
+      Position: [-3.06509781, -1.70000005, 0]
+      Rotation: [0, 0, 0]
+      Scale: [15, 0.5, 1]
+    SpriteRendererComponent:
+      Color: [0, 0.421940923, 0.416917831, 1]
+      Path: ""
+      Tiling: 1
+    Rigidbody2DComponent:
+      Type: Static
+      FixedRotation: false
+      Smoothing: Interpolation
+    BoxCollider2DComponent:
+      Offset: [0, 0]
+      Size: [0.5, 0.5]
+      Density: 1
+      Friction: 0.5
+      Restitution: 0
+      RestitutionThreshold: 0.5
   - Entity: 11764441337374806066
     TagComponent:
       Tag: Player
@@ -73,25 +117,39 @@ Entities:
       Friction: 0.5
       Restitution: 0
       RestitutionThreshold: 0.5
-  - Entity: 17908196038695326210
+  - Entity: 4439650569278229468
     TagComponent:
-      Tag: Ground
+      Tag: Camera
     TransformComponent:
-      Position: [-3.06509781, -1.70000005, 0]
+      Position: [0, 0, 0]
       Rotation: [0, 0, 0]
-      Scale: [15, 0.5, 1]
-    SpriteRendererComponent:
-      Color: [0, 0.421940923, 0.416917831, 1]
-      Path: ""
-      Tiling: 1
-    Rigidbody2DComponent:
-      Type: Static
-      FixedRotation: false
-      Smoothing: Interpolation
-    BoxCollider2DComponent:
-      Offset: [0, 0]
-      Size: [0.5, 0.5]
-      Density: 1
-      Friction: 0.5
-      Restitution: 0
-      RestitutionThreshold: 0.5
+      Scale: [1, 1, 1]
+    CameraComponent:
+      Camera:
+        ProjectionType: Perspective
+        PerspectiveFOV: 0.785398185
+        PerspectiveNear: 0.00999999978
+        PerspectiveFar: 1000
+        OrthographicSize: 10
+        OrthographicNear: -1
+        OrthographicFar: 10
+      Primary: true
+      FixedAspectRatio: false
+    ScriptComponent:
+      ClassName: GameProject.Source.Camera
+      ScriptFields:
+        - Name: DistanceFromPlayerMax
+          Type: Float
+          Data: 50
+        - Name: DistanceFromPlayer
+          Type: Float
+          Data: 0
+        - Name: DistanceFromPlayerMin
+          Type: Float
+          Data: 8
+        - Name: offSet
+          Type: Vector2
+          Data: [0, 2]
+        - Name: zoomSpeedPercentIncrease
+          Type: Float
+          Data: 0.5

--- a/Engine-Editor/GameProject/Assets/Scenes/ScriptRefactor.scene
+++ b/Engine-Editor/GameProject/Assets/Scenes/ScriptRefactor.scene
@@ -1,5 +1,67 @@
 Scene: ScriptRefactor.scene
 Entities:
+  - Entity: 17908196038695326210
+    TagComponent:
+      Tag: Ground
+    TransformComponent:
+      Position: [-3.06509781, -1.70000005, 0]
+      Rotation: [0, 0, 0]
+      Scale: [15, 0.5, 1]
+    SpriteRendererComponent:
+      Color: [0, 0.421940923, 0.416917831, 1]
+      Path: ""
+      Tiling: 1
+    Rigidbody2DComponent:
+      Type: Static
+      FixedRotation: false
+      Smoothing: Interpolation
+    BoxCollider2DComponent:
+      Offset: [0, 0]
+      Size: [0.5, 0.5]
+      Density: 1
+      Friction: 0.5
+      Restitution: 0
+      RestitutionThreshold: 0.5
+  - Entity: 11764441337374806066
+    TagComponent:
+      Tag: Player
+    TransformComponent:
+      Position: [0, 0, 0]
+      Rotation: [0, 0, 0]
+      Scale: [1, 1, 1]
+    SpriteRendererComponent:
+      Color: [0, 1, 0.607594967, 1]
+      Path: Textures\shipGreen_manned.png
+      Tiling: 1
+    ScriptComponent:
+      ClassName: GameProject.Source.Player
+      ScriptFields:
+        - Name: moveSpeed
+          Type: Float
+          Data: 50
+        - Name: rotSpeeed
+          Type: Float
+          Data: 2.20000005
+        - Name: movement
+          Type: Vector2
+          Data: [0, 0]
+        - Name: zoomSpeed
+          Type: Float
+          Data: 2
+        - Name: exampleString
+          Type: String
+          Data: Chicken
+    Rigidbody2DComponent:
+      Type: Dynamic
+      FixedRotation: false
+      Smoothing: Interpolation
+    BoxCollider2DComponent:
+      Offset: [0, 0]
+      Size: [0.5, 0.5]
+      Density: 1
+      Friction: 0.5
+      Restitution: 0
+      RestitutionThreshold: 0.5
   - Entity: 4439650569278229468
     TagComponent:
       Tag: Camera
@@ -24,62 +86,3 @@ Entities:
         - Name: DistanceFromPlayer
           Type: Float
           Data: 5
-  - Entity: 11764441337374806066
-    TagComponent:
-      Tag: Player
-    TransformComponent:
-      Position: [0, 0, 0]
-      Rotation: [0, 0, 0]
-      Scale: [1, 1, 1]
-    SpriteRendererComponent:
-      Color: [0, 1, 0.607594967, 1]
-      Path: Textures\shipGreen_manned.png
-      Tiling: 1
-    ScriptComponent:
-      ClassName: GameProject.Source.Player
-      ScriptFields:
-        - Name: moveSpeed
-          Type: Float
-          Data: 50
-        - Name: rotSpeeed
-          Type: Float
-          Data: 2.20000005
-        - Name: zoomSpeed
-          Type: Float
-          Data: 8.60000038
-        - Name: exampleString
-          Type: String
-          Data: Chicken
-    Rigidbody2DComponent:
-      Type: Dynamic
-      FixedRotation: false
-      Smoothing: Interpolation
-    BoxCollider2DComponent:
-      Offset: [0, 0]
-      Size: [0.5, 0.5]
-      Density: 1
-      Friction: 0.5
-      Restitution: 0
-      RestitutionThreshold: 0.5
-  - Entity: 17908196038695326210
-    TagComponent:
-      Tag: Ground
-    TransformComponent:
-      Position: [-3.06509781, -1.70000005, 0]
-      Rotation: [0, 0, 0]
-      Scale: [15, 0.5, 1]
-    SpriteRendererComponent:
-      Color: [0, 0.421940923, 0.416917831, 1]
-      Path: ""
-      Tiling: 1
-    Rigidbody2DComponent:
-      Type: Static
-      FixedRotation: false
-      Smoothing: Interpolation
-    BoxCollider2DComponent:
-      Offset: [0, 0]
-      Size: [0.5, 0.5]
-      Density: 1
-      Friction: 0.5
-      Restitution: 0
-      RestitutionThreshold: 0.5

--- a/Engine-Editor/GameProject/Assets/Scripts/Source/Camera.cs
+++ b/Engine-Editor/GameProject/Assets/Scripts/Source/Camera.cs
@@ -7,25 +7,42 @@ namespace GameProject.Source
 	public class Camera : Entity
 	{
 		public float DistanceFromPlayer = 5.0f;
+		public float DistanceFromPlayerMin = 5.0f;
+		public float DistanceFromPlayerMax = 50.0f;
+
+		public float zoomSpeedPercentIncrease = 1.0f;
+		public Vector2 offSet = new(0.0f, -2.0f);
 
 		Entity player;
+		Rigidbody2DComponent playerRb2d;
 
 		protected override void OnStart()
 		{
 			player ??= FindEntityByName("Player");
+			playerRb2d = player.GetComponent<Rigidbody2DComponent>();
 		}
 
 		protected override void OnLateUpdate(float ts)
 		{
 			if (player != null)
 			{
-				Vector2 playerPos = player.Position;
-				Position = new Vector3(playerPos.X, playerPos.Y, DistanceFromPlayer);
+				Vector2 playerPos = player.Position; 
+				Position = new Vector3(playerPos + offSet, MaintainDistanceFromPlayer(0.7f));
 			}
 			else
 			{
 				Log.Error($"Player is null!");
 			}
+		}
+
+		float MaintainDistanceFromPlayer(float ts)
+		{
+			float playerVelocityY = playerRb2d.LinearVelocity.Y;
+			if (playerVelocityY > 0.0f)
+				DistanceFromPlayer = playerVelocityY * (1.0f + zoomSpeedPercentIncrease * ts);
+
+			Mathf.Lerp(Position.Y + offSet.Y, DistanceFromPlayer, ts);
+			return Mathf.Clamp(DistanceFromPlayer, DistanceFromPlayerMin, DistanceFromPlayerMax);
 		}
 	}
 }

--- a/Engine-Editor/GameProject/Assets/Scripts/Source/Camera.cs
+++ b/Engine-Editor/GameProject/Assets/Scripts/Source/Camera.cs
@@ -10,9 +10,9 @@ namespace GameProject.Source
 
 		Entity player;
 
-		protected override void OnCreate()
+		protected override void OnStart()
 		{
-			player = FindEntityByName("Player");
+			player ??= FindEntityByName("Player");
 		}
 
 		protected override void OnLateUpdate(float ts)

--- a/Engine-Editor/GameProject/Assets/Scripts/Source/Camera.cs
+++ b/Engine-Editor/GameProject/Assets/Scripts/Source/Camera.cs
@@ -6,7 +6,7 @@ namespace GameProject.Source
 {
 	public class Camera : Entity
 	{
-		public float DistanceFromPlayer = 5.0f;
+		public float DistanceFromPlayer;
 		public float DistanceFromPlayerMin = 5.0f;
 		public float DistanceFromPlayerMax = 50.0f;
 

--- a/Engine-Editor/GameProject/Assets/Scripts/Source/Camera.cs
+++ b/Engine-Editor/GameProject/Assets/Scripts/Source/Camera.cs
@@ -15,7 +15,7 @@ namespace GameProject.Source
 			player = FindEntityByName("Player");
 		}
 
-		protected override void OnUpdate(float ts)
+		protected override void OnLateUpdate(float ts)
 		{
 			if (player != null)
 			{

--- a/Engine-Editor/GameProject/Assets/Scripts/Source/Player.cs
+++ b/Engine-Editor/GameProject/Assets/Scripts/Source/Player.cs
@@ -22,10 +22,13 @@ namespace GameProject.Source
 			rb2d = GetComponent<Rigidbody2DComponent>();
 		}
 
-		protected override void OnUpdate(float ts)
+		protected override void OnStart()
 		{
 			camera ??= FindEntityByName("Camera").As<Camera>();
+		}
 
+		protected override void OnUpdate(float ts)
+		{
 			if (Input.IsMouseButtonPressed(MouseCode.ButtonRight))
 			{
 				Vector2 curMousePos = Input.GetMousePosition();

--- a/Engine-Editor/GameProject/Assets/Scripts/Source/Player.cs
+++ b/Engine-Editor/GameProject/Assets/Scripts/Source/Player.cs
@@ -8,7 +8,7 @@ namespace GameProject.Source
 	{
 		public float moveSpeed = 5.0f;
 		public float rotSpeeed = 5.0f;
-		public Vector2 movement = new Vector2();
+		public Vector2 movement;
 
 		public float zoomSpeed = 1.0f;
 		public Camera camera = null;
@@ -20,21 +20,10 @@ namespace GameProject.Source
 		protected override void OnCreate()
 		{
 			rb2d = GetComponent<Rigidbody2DComponent>();
-
-			Log.Trace($"Move Speed: {moveSpeed}");
-			Log.Trace($"Rotation Speed: {rotSpeeed}");
-			Log.Trace($"Zoom Speed: {zoomSpeed}");
-		}
-
-		protected override void OnDestroy()
-		{
-			Log.Warn("Example Entity Destroyed.");
 		}
 
 		protected override void OnUpdate(float ts)
 		{
-			// Log.Trace($"Timestep: {ts}");
-
 			camera ??= FindEntityByName("Camera").As<Camera>();
 
 			if (Input.IsMouseButtonPressed(MouseCode.ButtonRight))
@@ -87,15 +76,7 @@ namespace GameProject.Source
 
 			if (camera != null)
 			{
-				if (Input.IsKeyPressed(KeyCode.Left))
-				{
-					camera.DistanceFromPlayer -= zoomSpeed * ts;
-				}
-
-				if (Input.IsKeyPressed(KeyCode.Right))
-				{
-					camera.DistanceFromPlayer += zoomSpeed * ts;
-				}
+				camera.DistanceFromPlayer += zoomSpeed * ts;
 			}
 			else
 			{

--- a/Engine-Editor/GameProject/Assets/Scripts/Source/Player.cs
+++ b/Engine-Editor/GameProject/Assets/Scripts/Source/Player.cs
@@ -10,9 +10,6 @@ namespace GameProject.Source
 		public float rotSpeeed = 5.0f;
 		public Vector2 movement;
 
-		public float zoomSpeed = 1.0f;
-		public Camera camera = null;
-
 		public string exampleString = "Example";
 
 		private Rigidbody2DComponent rb2d = null;
@@ -20,11 +17,6 @@ namespace GameProject.Source
 		protected override void OnCreate()
 		{
 			rb2d = GetComponent<Rigidbody2DComponent>();
-		}
-
-		protected override void OnStart()
-		{
-			camera ??= FindEntityByName("Camera").As<Camera>();
 		}
 
 		protected override void OnUpdate(float ts)
@@ -75,15 +67,6 @@ namespace GameProject.Source
 				Vector3 rotation = Transform.Rotation;
 				rotation.Z += -1.0f * rotSpeeed * ts;
 				Transform.Rotation = rotation;
-			}
-
-			if (camera != null)
-			{
-				camera.DistanceFromPlayer += zoomSpeed * ts;
-			}
-			else
-			{
-				Log.Error("Camera is null!");
 			}
 		}
 	}

--- a/Engine-Editor/GameProject/Assets/Scripts/Source/VariableValidator.cs
+++ b/Engine-Editor/GameProject/Assets/Scripts/Source/VariableValidator.cs
@@ -1,0 +1,66 @@
+﻿using Engine.Core;
+using Engine.Math;
+using Engine.Scene;
+
+namespace GameProject.Source
+{
+	public class VariableValidator : Entity
+	{
+		public bool Var0		= false;
+		public char Var1		= 'Y';
+		public string Var2		= "Hello There!";
+		public float Var3		= 192.123f;
+		public double Var4		= 1237.1232f;
+		public sbyte Var5		= -96;
+		public byte Var6		= 240;
+		public short Var7		= -2400;
+		public ushort Var8		= 2400;
+		public int Var9			= -21654;
+		public uint Var10		= 31654;
+		public long Var11		= -3165;
+		public ulong Var12		= 6316545;
+		public Vector2 Var13	= new(1234, -1234);
+		public Vector3 Var14	= new(-1234, 1234, 98723);
+		public Vector4 Var15	= new(1234, 1234, -98723, 12356);
+		public Entity Var16		= null;
+
+		protected override void OnCreate()
+		{
+			if (Var0)
+			{
+				PrintVar(Var0);
+				PrintVar(Var1);
+				PrintVar(Var2);
+				PrintVar(Var3);
+				PrintVar(Var4);
+				PrintVar(Var5);
+				PrintVar(Var6);
+				PrintVar(Var7);
+				PrintVar(Var8);
+				PrintVar(Var9);
+				PrintVar(Var10);
+				PrintVar(Var11);
+				PrintVar(Var12);
+				PrintVar(Var13);
+				PrintVar(Var14);
+				PrintVar(Var15);
+				PrintVar(Var16);
+			}
+		}
+
+		void PrintVar<T>(T var)
+		{
+			if (var == null)
+				return;
+
+			if (var.GetType().Equals("System.String") || var.GetType().Equals("System.Char"))
+			{
+				Log.Trace($"Var: {var.GetType()} = " + var);
+			}
+			else
+			{
+				Log.Trace($"Var: {var.GetType()} = {var}");
+			}
+		}
+	}
+}

--- a/Engine-Editor/imgui.ini
+++ b/Engine-Editor/imgui.ini
@@ -1,5 +1,4 @@
 [Window][DockSpace Demo]
-Pos=0,0
 Size=1600,900
 Collapsed=0
 
@@ -9,59 +8,70 @@ Size=400,400
 Collapsed=0
 
 [Window][Settings]
-Pos=1320,463
-Size=280,437
+Pos=1230,460
+Size=370,440
 Collapsed=0
-DockId=0x00000004,0
+DockId=0x00000002,0
 
 [Window][Viewport]
-Pos=465,80
-Size=853,542
-Collapsed=0
-DockId=0x0000000C,0
-
-[Window][Scene Hierarchy]
-Pos=0,22
-Size=463,423
-Collapsed=0
-DockId=0x00000005,0
-
-[Window][Properties]
-Pos=0,447
-Size=463,453
+Pos=372,70
+Size=856,552
 Collapsed=0
 DockId=0x00000006,0
 
-[Window][Stats]
-Pos=1320,22
-Size=280,439
-Collapsed=0
-DockId=0x00000003,0
-
-[Window][Content Browser]
-Pos=465,624
-Size=853,276
-Collapsed=0
-DockId=0x0000000B,0
-
-[Window][##toolbar]
-Pos=465,22
-Size=853,56
+[Window][Scene Hierarchy]
+Pos=0,22
+Size=370,439
 Collapsed=0
 DockId=0x0000000A,0
 
+[Window][Properties]
+Pos=0,463
+Size=370,437
+Collapsed=0
+DockId=0x0000000B,0
+
+[Window][Stats]
+Pos=1230,22
+Size=370,436
+Collapsed=0
+DockId=0x00000001,0
+
+[Window][Content Browser]
+Pos=372,624
+Size=856,276
+Collapsed=0
+DockId=0x0000000C,0
+
+[Window][##toolbar]
+Pos=372,22
+Size=856,46
+Collapsed=0
+DockId=0x00000007,0
+
+[Window][Dear ImGui Demo]
+ViewportPos=1922,461
+ViewportId=0xE927CF2F
+Size=550,680
+Collapsed=0
+
+[Window][DockSpace]
+Pos=0,0
+Size=1600,900
+Collapsed=0
+
 [Docking][Data]
-DockSpace         ID=0x3BC79352 Window=0x4647B76E Pos=462,321 Size=1600,878 Split=X Selected=0x995B0CF8
-  DockNode        ID=0x00000007 Parent=0x3BC79352 SizeRef=1054,701 Split=X
-    DockNode      ID=0x00000001 Parent=0x00000007 SizeRef=463,701 Split=Y Selected=0x9A68760C
-      DockNode    ID=0x00000005 Parent=0x00000001 SizeRef=370,391 Selected=0x9A68760C
-      DockNode    ID=0x00000006 Parent=0x00000001 SizeRef=370,419 Selected=0xC89E3217
-    DockNode      ID=0x00000002 Parent=0x00000007 SizeRef=853,701 Split=Y Selected=0x995B0CF8
-      DockNode    ID=0x00000009 Parent=0x00000002 SizeRef=853,534 Split=Y Selected=0x995B0CF8
-        DockNode  ID=0x0000000A Parent=0x00000009 SizeRef=918,56 HiddenTabBar=1 Selected=0x28257B55
-        DockNode  ID=0x0000000C Parent=0x00000009 SizeRef=918,542 CentralNode=1 HiddenTabBar=1 Selected=0x995B0CF8
-      DockNode    ID=0x0000000B Parent=0x00000002 SizeRef=853,245 Selected=0x371352B7
-  DockNode        ID=0x00000008 Parent=0x3BC79352 SizeRef=224,701 Split=Y Selected=0x968648AE
-    DockNode      ID=0x00000003 Parent=0x00000008 SizeRef=308,439 Selected=0x968648AE
-    DockNode      ID=0x00000004 Parent=0x00000008 SizeRef=308,437 Selected=0x1C33C293
+DockSpace         ID=0x09EF459F Window=0x9A404470 Pos=581,324 Size=1600,878 Split=X
+  DockNode        ID=0x00000005 Parent=0x09EF459F SizeRef=370,878 Split=Y Selected=0x9A68760C
+    DockNode      ID=0x0000000A Parent=0x00000005 SizeRef=462,439 Selected=0x9A68760C
+    DockNode      ID=0x0000000B Parent=0x00000005 SizeRef=462,437 Selected=0xC89E3217
+  DockNode        ID=0x00000009 Parent=0x09EF459F SizeRef=1228,878 Split=X
+    DockNode      ID=0x00000003 Parent=0x00000009 SizeRef=856,0 Split=Y
+      DockNode    ID=0x00000007 Parent=0x00000003 SizeRef=853,46 CentralNode=1 HiddenTabBar=1 Selected=0x28257B55
+      DockNode    ID=0x00000008 Parent=0x00000003 SizeRef=853,830 Split=Y Selected=0x995B0CF8
+        DockNode  ID=0x00000006 Parent=0x00000008 SizeRef=856,552 HiddenTabBar=1 Selected=0x995B0CF8
+        DockNode  ID=0x0000000C Parent=0x00000008 SizeRef=856,276 Selected=0x371352B7
+    DockNode      ID=0x00000004 Parent=0x00000009 SizeRef=370,878 Split=Y Selected=0x1C33C293
+      DockNode    ID=0x00000001 Parent=0x00000004 SizeRef=370,436 Selected=0x968648AE
+      DockNode    ID=0x00000002 Parent=0x00000004 SizeRef=370,440 Selected=0x1C33C293
 

--- a/Engine-Editor/src/EditorLayer.cpp
+++ b/Engine-Editor/src/EditorLayer.cpp
@@ -228,7 +228,7 @@ namespace Engine
 		m_ViewportFocused = ImGui::IsWindowFocused();
 		m_ViewportHovered = ImGui::IsWindowHovered();
 		Application::Get().GetImGuiLayer()->BlockEvents(!m_ViewportFocused && !m_ViewportHovered);
-		
+
 		ImVec2 viewportPanelSize = ImGui::GetContentRegionAvail();
 		m_ViewportSize = {viewportPanelSize.x, viewportPanelSize.y};
 		
@@ -477,6 +477,20 @@ namespace Engine
 			{
 				if (control)
 					OnDuplicateEntity();
+
+				break;
+			}
+			case Key::Delete:
+			{
+				if (Application::Get().GetImGuiLayer()->GetActiveWidgetID() == 0)
+				{
+					Entity selectedEntity = m_SceneHierarchyPanel.GetSelectedEntity();
+					if (selectedEntity)
+					{
+						m_SceneHierarchyPanel.SetSelectedEntity({});
+						m_EditorScene->DestroyEntity(selectedEntity);
+					}
+				}
 
 				break;
 			}

--- a/Engine-Editor/src/EditorLayer.cpp
+++ b/Engine-Editor/src/EditorLayer.cpp
@@ -134,7 +134,7 @@ namespace Engine
 	        window_flags |= ImGuiWindowFlags_NoBackground;
 
 	    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
-	    ImGui::Begin("DockSpace Demo", &dockspaceOpen, window_flags);
+	    ImGui::Begin("DockSpace", &dockspaceOpen, window_flags);
 	    ImGui::PopStyleVar();
 
 	    if (opt_fullscreen)
@@ -152,8 +152,6 @@ namespace Engine
 	    }
 		
 		style.WindowMinSize.x = minWinSizeX;
-
-		ImGui::ShowDemoWindow();
 
 	    if (ImGui::BeginMenuBar())
 	    {

--- a/Engine-Editor/src/EditorLayer.cpp
+++ b/Engine-Editor/src/EditorLayer.cpp
@@ -180,8 +180,12 @@ namespace Engine
 			if (ImGui::BeginMenu("Script"))
 	        {
 
-	        	if (ImGui::MenuItem("Reload Assembly", "Crtl+R"))
+				if (ImGui::MenuItem("Reload Assembly", "Crtl+R"))
+				{
 					ScriptEngine::ReloadAssembly();
+					// TODO prompt user to save any changes before reloading scene
+					OpenScene(m_EditorScenePath); // reload scene to match new assembly state
+				}
 
 	            ImGui::EndMenu();
 	        }

--- a/Engine-Editor/src/EditorLayer.cpp
+++ b/Engine-Editor/src/EditorLayer.cpp
@@ -678,7 +678,8 @@ namespace Engine
 		Entity selectedEntity = m_SceneHierarchyPanel.GetSelectedEntity();
 		if (selectedEntity)
 		{
-			m_ActiveScene->DuplicateEntity(selectedEntity);
+			Entity newEntity = m_ActiveScene->DuplicateEntity(selectedEntity);
+			m_SceneHierarchyPanel.SetSelectedEntity(newEntity);
 		}
 	}
 

--- a/Engine-Editor/src/EditorLayer.cpp
+++ b/Engine-Editor/src/EditorLayer.cpp
@@ -153,6 +153,8 @@ namespace Engine
 		
 		style.WindowMinSize.x = minWinSizeX;
 
+		ImGui::ShowDemoWindow();
+
 	    if (ImGui::BeginMenuBar())
 	    {
 	        if (ImGui::BeginMenu("File"))

--- a/Engine-Editor/src/Panels/SceneHierarchyPanel.cpp
+++ b/Engine-Editor/src/Panels/SceneHierarchyPanel.cpp
@@ -120,9 +120,9 @@ namespace Engine
 
 		if(entityDeleted)
 		{
-			m_Context->DestroyEntity(entity);
 			if (m_SelectionContext == entity)
 				m_SelectionContext = {};
+			m_Context->DestroyEntity(entity);
 		}
 	}
 

--- a/Engine-Editor/src/Panels/SceneHierarchyPanel.cpp
+++ b/Engine-Editor/src/Panels/SceneHierarchyPanel.cpp
@@ -10,19 +10,15 @@
 
 namespace Engine
 {
+#define SETUP_SCRIPT_FIELD(name, field, sceneRunning, fieldExists, entityFields)					\
+	ScriptFieldInstance& scriptField = fieldExists ? entityFields.at(name) : entityFields[name];	\
+	if (!sceneRunning && !fieldExists)																\
+		scriptField.Field = field;																	\
+
 	static void FieldTypeUnsupported(const ScriptFieldType& fieldType)
 	{
 		const char* typeName = Utils::ScriptFieldTypeToString(fieldType);
 		ImGui::Text(typeName);
-	}
-
-	static ScriptFieldInstance SetupScriptField(const std::string& name, const ScriptField& field, const bool& sceneRunning, const bool& fieldExists, ScriptFieldMap& entityFields)
-	{
-		ScriptFieldInstance& scriptField = fieldExists ? entityFields.at(name) : entityFields[name];
-		if (!sceneRunning && !fieldExists)
-			scriptField.Field = field;
-
-		return scriptField;
 	}
 
 	SceneHierarchyPanel::SceneHierarchyPanel(const Ref<Scene>& context)
@@ -481,7 +477,7 @@ namespace Engine
 				{
 				case ScriptFieldType::Float:
 				{
-					ScriptFieldInstance scriptField = SetupScriptField(name, field, sceneRunning, fieldExists, entityFields);
+					SETUP_SCRIPT_FIELD(name, field, sceneRunning, fieldExists, entityFields);
 
 					float data = sceneRunning ? scriptInstance->GetFieldValue<float>(name) : fieldExists ? scriptField.GetValue<float>() : 0.0f; // default 0.0 TODO read script default value
 					if (ImGui::DragFloat(("##" + name).c_str(), &data, 0.1f))
@@ -499,11 +495,11 @@ namespace Engine
 					break;
 				case ScriptFieldType::String:
 				{
-					ScriptFieldInstance scriptField = SetupScriptField(name, field, sceneRunning, fieldExists, entityFields);
+					SETUP_SCRIPT_FIELD(name, field, sceneRunning, fieldExists, entityFields);
 
 					char buffer[64];
 					memset(buffer, 0, sizeof(buffer));
-					strcpy_s(buffer, sizeof(buffer), sceneRunning ? scriptInstance->GetFieldValue<std::string>(name).c_str() : fieldExists ? scriptField.GetValue<std::string>().c_str() : "");
+					strcpy_s(buffer, sizeof(buffer), sceneRunning ? scriptInstance->GetFieldValue<std::string>(name).c_str() : fieldExists ? scriptField.GetValue<std::string>().c_str() : ""); // default "" TODO read script default value
 					if (ImGui::InputText(("##" + name).c_str(), buffer, sizeof(buffer), ImGuiInputTextFlags_EnterReturnsTrue))
 						sceneRunning ? scriptInstance->SetFieldValue(name, &std::string(buffer)) : scriptField.SetValue(std::string(buffer));
 					break;
@@ -533,14 +529,32 @@ namespace Engine
 					FieldTypeUnsupported(field.Type);
 					break;
 				case ScriptFieldType::Vector2:
-					FieldTypeUnsupported(field.Type);
+				{
+					SETUP_SCRIPT_FIELD(name, field, sceneRunning, fieldExists, entityFields);
+
+					glm::vec2 data = sceneRunning ? scriptInstance->GetFieldValue<glm::vec2>(name) : fieldExists ? scriptField.GetValue<glm::vec2>() : glm::vec2{}; // default {} TODO read script default value
+					if (ImGui::DragFloat2(("##" + name).c_str(), glm::value_ptr(data), 0.1f))
+						sceneRunning ? scriptInstance->SetFieldValue(name, &data) : scriptField.SetValue(data);
 					break;
+				}
 				case ScriptFieldType::Vector3:
-					FieldTypeUnsupported(field.Type);
+				{
+					SETUP_SCRIPT_FIELD(name, field, sceneRunning, fieldExists, entityFields);
+
+					glm::vec3 data = sceneRunning ? scriptInstance->GetFieldValue<glm::vec3>(name) : fieldExists ? scriptField.GetValue<glm::vec3>() : glm::vec3{}; // default {} TODO read script default value
+					if (ImGui::DragFloat3(("##" + name).c_str(), glm::value_ptr(data), 0.1f))
+						sceneRunning ? scriptInstance->SetFieldValue(name, &data) : scriptField.SetValue(data);
 					break;
+				}
 				case ScriptFieldType::Vector4:
-					FieldTypeUnsupported(field.Type);
+				{
+					SETUP_SCRIPT_FIELD(name, field, sceneRunning, fieldExists, entityFields);
+
+					glm::vec4 data = sceneRunning ? scriptInstance->GetFieldValue<glm::vec4>(name) : fieldExists ? scriptField.GetValue<glm::vec4>() : glm::vec4{}; // default {} TODO read script default value
+					if (ImGui::DragFloat4(("##" + name).c_str(), glm::value_ptr(data), 0.1f))
+						sceneRunning ? scriptInstance->SetFieldValue(name, &data) : scriptField.SetValue(data);
 					break;
+				}
 				case ScriptFieldType::Entity:
 					FieldTypeUnsupported(field.Type);
 					break;

--- a/Engine-Editor/src/Panels/SceneHierarchyPanel.cpp
+++ b/Engine-Editor/src/Panels/SceneHierarchyPanel.cpp
@@ -510,10 +510,7 @@ namespace Engine
 					memset(buffer, 0, sizeof(buffer));
 					buffer[0] = sceneRunning ? scriptInstance->GetFieldValue<char>(name) : fieldExists ? scriptField.GetValue<char>() : ' '; // default ' ' TODO read script default value
 					if (ImGui::InputText(("##" + name).c_str(), buffer, sizeof(buffer), ImGuiInputTextFlags_EnterReturnsTrue))
-					{
 						sceneRunning ? scriptInstance->SetFieldValue(name, &buffer[0]) : scriptField.SetValue(buffer[0]);
-					}
-
 					break;
 				}
 				case ScriptFieldType::String:

--- a/Engine-Editor/src/Panels/SceneHierarchyPanel.cpp
+++ b/Engine-Editor/src/Panels/SceneHierarchyPanel.cpp
@@ -505,12 +505,15 @@ namespace Engine
 				case ScriptFieldType::Char:
 				{
 					SETUP_SCRIPT_FIELD(name, field, sceneRunning, fieldExists, entityFields);
-
+					
 					char buffer[2];
 					memset(buffer, 0, sizeof(buffer));
-					strcpy_s(buffer, sizeof(buffer), sceneRunning ? scriptInstance->GetFieldValue<std::string>(name).c_str() : fieldExists ? scriptField.GetValue<std::string>().c_str() : ""); // default "" TODO read script default value
-					if (ImGui::InputText(("##" + name).c_str(), buffer, sizeof(buffer)))
-						sceneRunning ? scriptInstance->SetFieldValue(name, &std::string(buffer)) : scriptField.SetValue(std::string(buffer));
+					buffer[0] = sceneRunning ? scriptInstance->GetFieldValue<char>(name) : fieldExists ? scriptField.GetValue<char>() : ' '; // default ' ' TODO read script default value
+					if (ImGui::InputText(("##" + name).c_str(), buffer, sizeof(buffer), ImGuiInputTextFlags_EnterReturnsTrue))
+					{
+						sceneRunning ? scriptInstance->SetFieldValue(name, &buffer[0]) : scriptField.SetValue(buffer[0]);
+					}
+
 					break;
 				}
 				case ScriptFieldType::String:

--- a/Engine-Editor/src/Panels/SceneHierarchyPanel.cpp
+++ b/Engine-Editor/src/Panels/SceneHierarchyPanel.cpp
@@ -479,20 +479,40 @@ namespace Engine
 				{
 					SETUP_SCRIPT_FIELD(name, field, sceneRunning, fieldExists, entityFields);
 
-					float data = sceneRunning ? scriptInstance->GetFieldValue<float>(name) : fieldExists ? scriptField.GetValue<float>() : 0.0f; // default 0.0 TODO read script default value
+					float data = sceneRunning ? scriptInstance->GetFieldValue<float>(name) : fieldExists ? scriptField.GetValue<float>() : 0.0f; // default 0.0f TODO read script default value
 					if (ImGui::DragFloat(("##" + name).c_str(), &data, 0.1f))
 						sceneRunning ? scriptInstance->SetFieldValue(name, &data) : scriptField.SetValue(data);
 					break;
 				}
 				case ScriptFieldType::Double:
-					FieldTypeUnsupported(field.Type);
+				{
+					SETUP_SCRIPT_FIELD(name, field, sceneRunning, fieldExists, entityFields);
+
+					double data = sceneRunning ? scriptInstance->GetFieldValue<double>(name) : fieldExists ? scriptField.GetValue<double>() : 0.0; // default 0.0 TODO read script default value
+					if (ImGui::DragScalar(("##" + name).c_str(), ImGuiDataType_Double, &data, 0.1))
+						sceneRunning ? scriptInstance->SetFieldValue(name, &data) : scriptField.SetValue(data);
 					break;
+				}
 				case ScriptFieldType::Bool:
-					FieldTypeUnsupported(field.Type);
+				{
+					SETUP_SCRIPT_FIELD(name, field, sceneRunning, fieldExists, entityFields);
+
+					bool data = sceneRunning ? scriptInstance->GetFieldValue <bool> (name) : fieldExists ? scriptField.GetValue<bool>() : false; // default false TODO read script default value
+					if (ImGui::Checkbox(("##" + name).c_str(), &data))
+						sceneRunning ? scriptInstance->SetFieldValue(name, &data) : scriptField.SetValue(data);
 					break;
+				}
 				case ScriptFieldType::Char:
-					FieldTypeUnsupported(field.Type);
+				{
+					SETUP_SCRIPT_FIELD(name, field, sceneRunning, fieldExists, entityFields);
+
+					char buffer[2];
+					memset(buffer, 0, sizeof(buffer));
+					strcpy_s(buffer, sizeof(buffer), sceneRunning ? scriptInstance->GetFieldValue<std::string>(name).c_str() : fieldExists ? scriptField.GetValue<std::string>().c_str() : ""); // default "" TODO read script default value
+					if (ImGui::InputText(("##" + name).c_str(), buffer, sizeof(buffer)))
+						sceneRunning ? scriptInstance->SetFieldValue(name, &std::string(buffer)) : scriptField.SetValue(std::string(buffer));
 					break;
+				}
 				case ScriptFieldType::String:
 				{
 					SETUP_SCRIPT_FIELD(name, field, sceneRunning, fieldExists, entityFields);
@@ -504,30 +524,78 @@ namespace Engine
 						sceneRunning ? scriptInstance->SetFieldValue(name, &std::string(buffer)) : scriptField.SetValue(std::string(buffer));
 					break;
 				}
-				case ScriptFieldType::Byte:
-					FieldTypeUnsupported(field.Type);
+				case ScriptFieldType::SByte:
+				{
+					SETUP_SCRIPT_FIELD(name, field, sceneRunning, fieldExists, entityFields);
+
+					int8_t data = sceneRunning ? scriptInstance->GetFieldValue<int8_t>(name) : fieldExists ? scriptField.GetValue<int8_t>() : 0; // default 0 TODO read script default value
+					if (ImGui::DragScalar(("##" + name).c_str(), ImGuiDataType_S8, &data))
+						sceneRunning ? scriptInstance->SetFieldValue(name, &data) : scriptField.SetValue(data);
 					break;
+				}
 				case ScriptFieldType::Short:
-					FieldTypeUnsupported(field.Type);
+				{
+					SETUP_SCRIPT_FIELD(name, field, sceneRunning, fieldExists, entityFields);
+
+					int16_t data = sceneRunning ? scriptInstance->GetFieldValue<int16_t>(name) : fieldExists ? scriptField.GetValue<int16_t>() : 0; // default 0 TODO read script default value
+					if (ImGui::DragScalar(("##" + name).c_str(), ImGuiDataType_S16, &data))
+						sceneRunning ? scriptInstance->SetFieldValue(name, &data) : scriptField.SetValue(data);
 					break;
+				}
 				case ScriptFieldType::Int:
-					FieldTypeUnsupported(field.Type);
+				{
+					SETUP_SCRIPT_FIELD(name, field, sceneRunning, fieldExists, entityFields);
+
+					int32_t data = sceneRunning ? scriptInstance->GetFieldValue<int32_t>(name) : fieldExists ? scriptField.GetValue<int32_t>() : 0; // default 0 TODO read script default value
+					if (ImGui::DragScalar(("##" + name).c_str(), ImGuiDataType_S32, &data))
+						sceneRunning ? scriptInstance->SetFieldValue(name, &data) : scriptField.SetValue(data);
 					break;
+				}
 				case ScriptFieldType::Long:
-					FieldTypeUnsupported(field.Type);
+				{
+					SETUP_SCRIPT_FIELD(name, field, sceneRunning, fieldExists, entityFields);
+
+					int64_t data = sceneRunning ? scriptInstance->GetFieldValue<int64_t>(name) : fieldExists ? scriptField.GetValue<int64_t>() : 0; // default 0 TODO read script default value
+					if (ImGui::DragScalar(("##" + name).c_str(), ImGuiDataType_S64, &data))
+						sceneRunning ? scriptInstance->SetFieldValue(name, &data) : scriptField.SetValue(data);
 					break;
-				case ScriptFieldType::UByte:
-					FieldTypeUnsupported(field.Type);
+				}
+				case ScriptFieldType::Byte:
+				{
+					SETUP_SCRIPT_FIELD(name, field, sceneRunning, fieldExists, entityFields);
+
+					uint8_t data = sceneRunning ? scriptInstance->GetFieldValue<uint8_t>(name) : fieldExists ? scriptField.GetValue<uint8_t>() : 0; // default 0 TODO read script default value
+					if (ImGui::DragScalar(("##" + name).c_str(), ImGuiDataType_U8, &data))
+						sceneRunning ? scriptInstance->SetFieldValue(name, &(uint8_t)data) : scriptField.SetValue((uint8_t)data);
 					break;
+				}
 				case ScriptFieldType::UShort:
-					FieldTypeUnsupported(field.Type);
+				{
+					SETUP_SCRIPT_FIELD(name, field, sceneRunning, fieldExists, entityFields);
+
+					uint16_t data = sceneRunning ? scriptInstance->GetFieldValue<uint16_t>(name) : fieldExists ? scriptField.GetValue<uint16_t>() : 0; // default 0 TODO read script default value
+					if (ImGui::DragScalar(("##" + name).c_str(), ImGuiDataType_U16, &data))
+						sceneRunning ? scriptInstance->SetFieldValue(name, &data) : scriptField.SetValue(data);
 					break;
+				}
 				case ScriptFieldType::UInt:
-					FieldTypeUnsupported(field.Type);
+				{
+					SETUP_SCRIPT_FIELD(name, field, sceneRunning, fieldExists, entityFields);
+
+					uint32_t data = sceneRunning ? scriptInstance->GetFieldValue<uint32_t>(name) : fieldExists ? scriptField.GetValue<uint32_t>() : 0; // default 0 TODO read script default value
+					if (ImGui::DragScalar(("##" + name).c_str(), ImGuiDataType_U32, &data))
+						sceneRunning ? scriptInstance->SetFieldValue(name, &data) : scriptField.SetValue(data);
 					break;
+				}
 				case ScriptFieldType::ULong:
-					FieldTypeUnsupported(field.Type);
+				{
+					SETUP_SCRIPT_FIELD(name, field, sceneRunning, fieldExists, entityFields);
+
+					uint64_t data = sceneRunning ? scriptInstance->GetFieldValue<uint64_t>(name) : fieldExists ? scriptField.GetValue<uint64_t>() : 0; // default 0 TODO read script default value
+					if (ImGui::DragScalar(("##" + name).c_str(), ImGuiDataType_U64, &data))
+						sceneRunning ? scriptInstance->SetFieldValue(name, &data) : scriptField.SetValue(data);
 					break;
+				}
 				case ScriptFieldType::Vector2:
 				{
 					SETUP_SCRIPT_FIELD(name, field, sceneRunning, fieldExists, entityFields);

--- a/Engine-Editor/src/Panels/SceneHierarchyPanel.cpp
+++ b/Engine-Editor/src/Panels/SceneHierarchyPanel.cpp
@@ -57,7 +57,7 @@ namespace Engine
 			{
 				if (ImGui::MenuItem("Create Empty Entity"))
 				{
-					m_Context->CreateEntity("Empty Entity");
+					m_Context->CreateEntity();
 				}
 				else if (ImGui::MenuItem("Create Sprite"))
 				{

--- a/Engine-ScriptCore/Source/Engine/Core/InternalCalls.cs
+++ b/Engine-ScriptCore/Source/Engine/Core/InternalCalls.cs
@@ -155,6 +155,9 @@ namespace Engine.Core
 		#region Rigidbody2DComponent
 
 		[MethodImpl(MethodImplOptions.InternalCall)]
+		internal static extern void Rigidbody2DComponent_GetLinearVelocity(ulong entityID, out Vector2 velocity);
+
+		[MethodImpl(MethodImplOptions.InternalCall)]
 		internal static extern void Rigidbody2DComponent_ApplyLinearImpulse(ulong entityID, ref Vector2 impulse, ref Vector2 worldPosition, bool wake);
 
 		[MethodImpl(MethodImplOptions.InternalCall)]

--- a/Engine-ScriptCore/Source/Engine/Math/Mathf.cs
+++ b/Engine-ScriptCore/Source/Engine/Math/Mathf.cs
@@ -1,0 +1,22 @@
+﻿using Engine.Core;
+
+using System;
+
+namespace Engine.Math
+{
+	public static class Mathf
+	{
+		//https://stackoverflow.com/questions/2683442/where-can-i-find-the-clamp-function-in-net
+		public static T Clamp<T>(this T val, T min, T max) where T : IComparable<T>
+		{
+			if (val.CompareTo(min) < 0) return min;
+			else if (val.CompareTo(max) > 0) return max;
+			else return val;
+		}
+
+		public static float Lerp(float a, float b, float t)
+		{
+			return a + t * (b - a);
+		}
+	}
+}

--- a/Engine-ScriptCore/Source/Engine/Math/Vector3.cs
+++ b/Engine-ScriptCore/Source/Engine/Math/Vector3.cs
@@ -33,6 +33,7 @@ namespace Engine.Math
 		public float sqrMagnitude => InternalCalls.Vector3_sqrMagnitude(ref this);
 
 		public static Vector3 operator +(Vector3 lhs, Vector3 rhs) => new Vector3(lhs.X + rhs.X, lhs.Y + rhs.Y, lhs.Z + rhs.Z);
+		public static Vector3 operator +(Vector3 lhs, Vector2 rhs) => new Vector3(lhs.X + rhs.X, lhs.Y + rhs.Y, 0.0f);
 		public static Vector3 operator -(Vector3 lhs, Vector3 rhs) => new Vector3(lhs.X - rhs.X, lhs.Y - rhs.Y, lhs.Z - rhs.Z);
 		public static Vector3 operator *(Vector3 lhs, float rhs) => new Vector3(lhs.X * rhs, lhs.Y * rhs, lhs.Z * rhs);
 	}

--- a/Engine-ScriptCore/Source/Engine/Scene/Components.cs
+++ b/Engine-ScriptCore/Source/Engine/Scene/Components.cs
@@ -67,6 +67,15 @@ namespace Engine.Scene
 
 	public class Rigidbody2DComponent : Component
 	{
+		public Vector2 LinearVelocity
+		{
+			get
+			{
+				InternalCalls.Rigidbody2DComponent_GetLinearVelocity(Entity.ID, out Vector2 velocity);
+				return velocity;
+			}
+		}
+
 		public void ApplyLinearImpulse(Vector2 impulse, Vector2 worldPosition, bool wake)
 		{
 			InternalCalls.Rigidbody2DComponent_ApplyLinearImpulse(Entity.ID, ref impulse, ref worldPosition, wake);

--- a/Engine-ScriptCore/Source/Engine/Scene/Entity.cs
+++ b/Engine-ScriptCore/Source/Engine/Scene/Entity.cs
@@ -16,6 +16,7 @@ namespace Engine.Scene
 		}
 
 		protected virtual void OnCreate() { }
+		protected virtual void OnStart() { }
 		protected virtual void OnDestroy() { }
 		protected virtual void OnUpdate(float ts) { }
 		protected virtual void OnLateUpdate(float ts) { }

--- a/Engine-ScriptCore/Source/Engine/Scene/Entity.cs
+++ b/Engine-ScriptCore/Source/Engine/Scene/Entity.cs
@@ -18,6 +18,7 @@ namespace Engine.Scene
 		protected virtual void OnCreate() { }
 		protected virtual void OnDestroy() { }
 		protected virtual void OnUpdate(float ts) { }
+		protected virtual void OnLateUpdate(float ts) { }
 
 		public bool HasComponent<T>() where T : Component, new()
 		{

--- a/GameEngine/src/Engine/ImGui/ImGuiLayer.cpp
+++ b/GameEngine/src/Engine/ImGui/ImGuiLayer.cpp
@@ -2,6 +2,7 @@
 #include "Engine/ImGui/ImGuiLayer.h"
 
 #include <imgui.h>
+#include <imgui_internal.h>
 #include <backends/imgui_impl_opengl3.cpp>
 #include <backends/imgui_impl_glfw.cpp>
 
@@ -142,4 +143,10 @@ namespace Engine
 		colors[ImGuiCol_TitleBgActive] = ImVec4{0.15f, 0.1505f, 0.151f, 1.0f};
 		colors[ImGuiCol_TitleBgCollapsed] = ImVec4{0.15f, 0.1505f, 0.151f, 1.0f};
 	}
+
+	uint32_t ImGuiLayer::GetActiveWidgetID() const
+	{
+		return GImGui->ActiveId;
+	}
+
 }

--- a/GameEngine/src/Engine/ImGui/ImGuiLayer.h
+++ b/GameEngine/src/Engine/ImGui/ImGuiLayer.h
@@ -22,6 +22,8 @@ namespace Engine
 		void BlockEvents(bool block) { m_BlockEvents = block; }
 		
 		void SetDarkThemeColors();
+
+		uint32_t GetActiveWidgetID() const;
 	private:
 		bool m_BlockEvents = true;
 	};

--- a/GameEngine/src/Engine/Scene/Scene.cpp
+++ b/GameEngine/src/Engine/Scene/Scene.cpp
@@ -153,10 +153,12 @@ namespace Engine
 		m_StepFrames = frames;
 	}
 
-	void Scene::DuplicateEntity(Entity entity)
+	Entity Scene::DuplicateEntity(Entity entity)
 	{
-		Entity newEntity = CreateEntity(entity.GetName());
+		std::string name = entity.GetName();
+		Entity newEntity = CreateEntity(name);
 		CopyComponentIfExists(AllComponents{}, newEntity, entity);
+		return newEntity;
 	}
 
 	Entity Scene::GetEntityWithUUID(UUID uuid)

--- a/GameEngine/src/Engine/Scene/Scene.cpp
+++ b/GameEngine/src/Engine/Scene/Scene.cpp
@@ -117,8 +117,8 @@ namespace Engine
 
 	void Scene::DestroyEntity(Entity entity)
 	{
-		m_Registry.destroy(entity);
 		m_EntityMap.erase(entity.GetUUID());
+		m_Registry.destroy(entity);
 	}
 
 	void Scene::OnViewportResize(uint32_t width, uint32_t height)

--- a/GameEngine/src/Engine/Scene/Scene.cpp
+++ b/GameEngine/src/Engine/Scene/Scene.cpp
@@ -107,8 +107,7 @@ namespace Engine
 
 		entity.AddComponent<IDComponent>(uuid);
 		entity.AddComponent<TransformComponent>();
-		auto& tag = entity.AddComponent<TagComponent>();
-		tag.Tag = name.empty() ? "Entity" : name;
+		entity.AddComponent<TagComponent>().Tag = name.empty() ? "Entity" : name;
 
 		m_EntityMap[uuid] = entity;
 

--- a/GameEngine/src/Engine/Scene/Scene.h
+++ b/GameEngine/src/Engine/Scene/Scene.h
@@ -32,7 +32,7 @@ namespace Engine
 
 		void Step(int frames = 1);
 
-		void DuplicateEntity(Entity entity);
+		Entity DuplicateEntity(Entity entity);
 		Entity GetEntityWithUUID(UUID uuid);
 		Entity FindEntityByName(const std::string_view& entityName);
 		

--- a/GameEngine/src/Engine/Scene/Scene.h
+++ b/GameEngine/src/Engine/Scene/Scene.h
@@ -26,30 +26,33 @@ namespace Engine
 		Entity CreateEntity(const std::string& name = std::string());
 		Entity CreateEntityWithUUID(UUID uuid, const std::string& name = std::string());
 		void DestroyEntity(Entity entity);
-		
-		void OnRuntimeStart();
-		void OnSimulationStart();
-
-		void OnRuntimeStop();
-		void OnSimulationStop();
-
-		void OnUpdateRuntime(Timestep ts);
-		void OnUpdateSimulation(Timestep ts, EditorCamera& camera);
-		void OnUpdateEditor(Timestep ts, EditorCamera& camera);
 
 		void OnViewportResize(uint32_t width, uint32_t height);
 		Entity GetPrimaryCameraEntity();
-
-		bool IsRunning() const { return m_IsRunning; }
-		bool IsPaused() const { return m_IsPaused; }
-
-		void SetPaused(bool paused) { m_IsPaused = paused; }
 
 		void Step(int frames = 1);
 
 		void DuplicateEntity(Entity entity);
 		Entity GetEntityWithUUID(UUID uuid);
 		Entity FindEntityByName(const std::string_view& entityName);
+		
+		// Start Play/Sim Whole
+		void OnRuntimeStart();
+		void OnSimulationStart();
+
+		// Stop Play/Sim Whole
+		void OnRuntimeStop();
+		void OnSimulationStop();
+
+		// Update Play/Sim Whole
+		void OnUpdateRuntime(Timestep ts);
+		void OnUpdateSimulation(Timestep ts, EditorCamera& camera);
+		void OnUpdateEditor(Timestep ts, EditorCamera& camera);
+
+		bool IsRunning() const { return m_IsRunning; }
+		bool IsPaused() const { return m_IsPaused; }
+
+		void SetPaused(bool paused) { m_IsPaused = paused; }
 
 		template<typename... Components>
 		auto GetAllEntitiesWith()
@@ -61,12 +64,16 @@ namespace Engine
 		template<typename T>
 		void OnComponentAdded(Entity entity, T& component);
 
+		// Start Play/Sim Section
 		void OnPhysics2DStart();
+		void OnScriptsCreate();
 		void OnScriptsStart();
 
+		// Stop Play/Sim Section
 		void OnPhysics2DStop();
 		void OnScriptsStop();
 
+		// Update Play/Sim Section
 		void OnScriptsUpdate(Timestep ts);
 		void OnPhysics2DUpdate(Timestep ts);
 		void OnScriptsLateUpdate(Timestep ts);

--- a/GameEngine/src/Engine/Scene/Scene.h
+++ b/GameEngine/src/Engine/Scene/Scene.h
@@ -67,8 +67,9 @@ namespace Engine
 		void OnPhysics2DStop();
 		void OnScriptsStop();
 
-		void OnPhysics2DUpdate(Timestep ts);
 		void OnScriptsUpdate(Timestep ts);
+		void OnPhysics2DUpdate(Timestep ts);
+		void OnScriptsLateUpdate(Timestep ts);
 		void OnRender2DUpdate();
 
 	private:
@@ -87,8 +88,8 @@ namespace Engine
 		float m_AccumulatorRatio = 0.0f;
 		const float m_PhysicsTimestep = 1.0f / 60.0f;
 		b2World* m_PhysicsWorld = nullptr;
-		uint32_t m_VelocityIteractions = 8;
-		uint32_t m_PositionIteractions = 3;
+		uint32_t m_VelocityIteractions = 20;
+		uint32_t m_PositionIteractions = 16;
 
 		friend class Entity;
 		friend class SceneSerializer;

--- a/GameEngine/src/Engine/Scene/SceneSerializer.cpp
+++ b/GameEngine/src/Engine/Scene/SceneSerializer.cpp
@@ -97,7 +97,7 @@ namespace YAML
 
 		static bool decode(const Node& node, Engine::UUID& uuid)
 		{
-			uuid = node[0].as<float>();
+			uuid = node[0].as<uint64_t>();
 			return true;
 		}
 	};
@@ -323,23 +323,23 @@ namespace Engine
 
 					switch (field.Type)
 					{
-						WRITE_SCRIPT_FIELD(Float,	float		);
-						WRITE_SCRIPT_FIELD(Double,	double		);
-						WRITE_SCRIPT_FIELD(Bool,	bool		);
-						WRITE_SCRIPT_FIELD(Char,	char		);
-						WRITE_SCRIPT_FIELD(String,	std::string	);
-						WRITE_SCRIPT_FIELD(Byte,	int8_t		);
-						WRITE_SCRIPT_FIELD(Short,	int16_t		);
-						WRITE_SCRIPT_FIELD(Int,		int32_t		);
-						WRITE_SCRIPT_FIELD(Long,	int64_t		);
-						WRITE_SCRIPT_FIELD(UByte,	uint8_t		);
-						WRITE_SCRIPT_FIELD(UShort,	uint16_t	);
-						WRITE_SCRIPT_FIELD(UInt,	uint32_t	);
-						WRITE_SCRIPT_FIELD(ULong,	uint64_t	);
-						WRITE_SCRIPT_FIELD(Vector2,	glm::vec2	);
-						WRITE_SCRIPT_FIELD(Vector3,	glm::vec3	);
-						WRITE_SCRIPT_FIELD(Vector4,	glm::vec4	);
-						WRITE_SCRIPT_FIELD(Entity,	UUID		);
+						WRITE_SCRIPT_FIELD(Float,	float			);
+						WRITE_SCRIPT_FIELD(Double,	double			);
+						WRITE_SCRIPT_FIELD(Bool,	bool			);
+						WRITE_SCRIPT_FIELD(Char,	std::string		); // handling char as a one character string
+						WRITE_SCRIPT_FIELD(String,	std::string		);
+						WRITE_SCRIPT_FIELD(SByte,	int8_t			);
+						WRITE_SCRIPT_FIELD(Short,	int16_t			);
+						WRITE_SCRIPT_FIELD(Int,		int32_t			);
+						WRITE_SCRIPT_FIELD(Long,	int64_t			);
+						WRITE_SCRIPT_FIELD(Byte,	uint16_t		); // upcasting uint8_t to unint16_t to fix yaml-cpp encode/decode
+						WRITE_SCRIPT_FIELD(UShort,	uint16_t		);
+						WRITE_SCRIPT_FIELD(UInt,	uint32_t		);
+						WRITE_SCRIPT_FIELD(ULong,	uint64_t		);
+						WRITE_SCRIPT_FIELD(Vector2,	glm::vec2		);
+						WRITE_SCRIPT_FIELD(Vector3,	glm::vec3		);
+						WRITE_SCRIPT_FIELD(Vector4,	glm::vec4		);
+						WRITE_SCRIPT_FIELD(Entity,	UUID			);
 					default:
 						ENGINE_CORE_ERROR("Script Field Type {} does not support serialization!", Utils::ScriptFieldTypeToString(field.Type));
 					}
@@ -555,23 +555,23 @@ namespace Engine
 
 							switch (type)
 							{
-								READ_SCRIPT_FIELD(Float,	float		);
-								READ_SCRIPT_FIELD(Double,	double		);
-								READ_SCRIPT_FIELD(Bool,		bool		);
-								READ_SCRIPT_FIELD(Char,		char		);
-								READ_SCRIPT_FIELD(String,	std::string	);
-								READ_SCRIPT_FIELD(Byte,		int8_t		);
-								READ_SCRIPT_FIELD(Short,	int16_t		);
-								READ_SCRIPT_FIELD(Int,		int32_t		);
-								READ_SCRIPT_FIELD(Long,		int64_t		);
-								READ_SCRIPT_FIELD(UByte,	uint8_t		);
-								READ_SCRIPT_FIELD(UShort,	uint16_t	);
-								READ_SCRIPT_FIELD(UInt,		uint32_t	);
-								READ_SCRIPT_FIELD(ULong,	uint64_t	);
-								READ_SCRIPT_FIELD(Vector2,	glm::vec2	);
-								READ_SCRIPT_FIELD(Vector3,	glm::vec3	);
-								READ_SCRIPT_FIELD(Vector4,	glm::vec4	);
-								READ_SCRIPT_FIELD(Entity,	UUID		);
+								READ_SCRIPT_FIELD(Float,	float			);
+								READ_SCRIPT_FIELD(Double,	double			);
+								READ_SCRIPT_FIELD(Bool,		bool			);
+								READ_SCRIPT_FIELD(Char,		std::string		); // handling char as a one character string
+								READ_SCRIPT_FIELD(String,	std::string		);
+								READ_SCRIPT_FIELD(SByte,	int8_t			);
+								READ_SCRIPT_FIELD(Short,	int16_t			);
+								READ_SCRIPT_FIELD(Int,		int32_t			);
+								READ_SCRIPT_FIELD(Long,		int64_t			);
+								READ_SCRIPT_FIELD(Byte,		uint16_t		); // upcasting uint8_t to unint16_t to fix yaml-cpp encode/decode
+								READ_SCRIPT_FIELD(UShort,	uint16_t		);
+								READ_SCRIPT_FIELD(UInt,		uint32_t		);
+								READ_SCRIPT_FIELD(ULong,	uint64_t		);
+								READ_SCRIPT_FIELD(Vector2,	glm::vec2		);
+								READ_SCRIPT_FIELD(Vector3,	glm::vec3		);
+								READ_SCRIPT_FIELD(Vector4,	glm::vec4		);
+								READ_SCRIPT_FIELD(Entity,	UUID			);
 							default:
 								ENGINE_CORE_ERROR("Script Field Type {} does not support deserialization!", Utils::ScriptFieldTypeToString(type));
 							}

--- a/GameEngine/src/Engine/Scene/SceneSerializer.cpp
+++ b/GameEngine/src/Engine/Scene/SceneSerializer.cpp
@@ -326,7 +326,7 @@ namespace Engine
 						WRITE_SCRIPT_FIELD(Float,	float			);
 						WRITE_SCRIPT_FIELD(Double,	double			);
 						WRITE_SCRIPT_FIELD(Bool,	bool			);
-						WRITE_SCRIPT_FIELD(Char,	std::string		); // handling char as a one character string
+						WRITE_SCRIPT_FIELD(Char,	char			);
 						WRITE_SCRIPT_FIELD(String,	std::string		);
 						WRITE_SCRIPT_FIELD(SByte,	int8_t			);
 						WRITE_SCRIPT_FIELD(Short,	int16_t			);
@@ -558,7 +558,7 @@ namespace Engine
 								READ_SCRIPT_FIELD(Float,	float			);
 								READ_SCRIPT_FIELD(Double,	double			);
 								READ_SCRIPT_FIELD(Bool,		bool			);
-								READ_SCRIPT_FIELD(Char,		std::string		); // handling char as a one character string
+								READ_SCRIPT_FIELD(Char,		char			);
 								READ_SCRIPT_FIELD(String,	std::string		);
 								READ_SCRIPT_FIELD(SByte,	int8_t			);
 								READ_SCRIPT_FIELD(Short,	int16_t			);

--- a/GameEngine/src/Engine/Scripting/ScriptEngine.cpp
+++ b/GameEngine/src/Engine/Scripting/ScriptEngine.cpp
@@ -25,6 +25,7 @@ namespace Engine
 		{ "System.Double",			ScriptFieldType::Double },
 		{ "System.Boolean",			ScriptFieldType::Bool },
 		{ "System.Char",			ScriptFieldType::Char },
+		{ "System.SByte",			ScriptFieldType::SByte },
 		{ "System.String",			ScriptFieldType::String },
 		{ "System.Int16",			ScriptFieldType::Short },
 		{ "System.Int32",			ScriptFieldType::Int },
@@ -446,6 +447,10 @@ namespace Engine
 					if (fieldInstance.Field.Type == ScriptFieldType::String)
 					{
 						instance->SetFieldValueInternal(name, ScriptEngine::StringToMonoString(*(std::string*)fieldInstance.m_Buffer));
+					}
+					else if (fieldInstance.Field.Type == ScriptFieldType::Char)
+					{
+						instance->SetFieldValueInternal(name, &fieldInstance.m_Buffer[sizeof(char*)]);
 					}
 					else
 					{

--- a/GameEngine/src/Engine/Scripting/ScriptEngine.cpp
+++ b/GameEngine/src/Engine/Scripting/ScriptEngine.cpp
@@ -448,12 +448,6 @@ namespace Engine
 					{
 						instance->SetFieldValueInternal(name, ScriptEngine::StringToMonoString(*(std::string*)fieldInstance.m_Buffer));
 					}
-					//else if (fieldInstance.Field.Type == ScriptFieldType::Char)
-					//{
-					//	std::string& buffer = *(std::string*)fieldInstance.m_Buffer;
-					//	const char* charBuffer = buffer.c_str();
-					//	instance->SetFieldValueInternal(name, charBuffer);
-					//}
 					else
 					{
 						instance->SetFieldValueInternal(name, fieldInstance.m_Buffer);

--- a/GameEngine/src/Engine/Scripting/ScriptEngine.cpp
+++ b/GameEngine/src/Engine/Scripting/ScriptEngine.cpp
@@ -18,7 +18,8 @@
 #include <FileWatch.hpp>
 
 namespace Engine
-{
+{				
+				
 	static std::unordered_map<std::string, ScriptFieldType> s_ScriptFieldTypeMap =
 	{
 		{ "System.Single",			ScriptFieldType::Float },
@@ -75,6 +76,7 @@ namespace Engine
 		std::unordered_map<std::string, Ref<ScriptClass>> EntityClasses;
 		std::unordered_map<UUID, Ref<ScriptInstance>> EntityInstances;
 		std::unordered_map<UUID, ScriptFieldMap> EntityScriptFields;
+		std::unordered_map<std::string, ScriptFieldMap> ScriptFieldsDefaults;
 
 		Scene* SceneContext;
 
@@ -190,6 +192,7 @@ namespace Engine
 		s_ScriptEngineData->EntityInstances.clear();
 		s_ScriptEngineData->EntityClasses.clear();
 		s_ScriptEngineData->EntityScriptFields.clear();
+		s_ScriptEngineData->ScriptFieldsDefaults.clear();
 		delete s_ScriptEngineData;
 	}
 
@@ -280,6 +283,7 @@ namespace Engine
 		s_ScriptEngineData->EntityInstances.clear();
 		s_ScriptEngineData->EntityClasses.clear();
 		s_ScriptEngineData->EntityScriptFields.clear();
+		s_ScriptEngineData->ScriptFieldsDefaults.clear();
 
 		// reload assemblies
 		if (!LoadCoreAssembly("Resources/Scripts/Binaries/Engine-ScriptCore.dll")) return;
@@ -292,6 +296,7 @@ namespace Engine
 	void ScriptEngine::LoadEntityClasses(MonoAssembly* assembly)
 	{
 		s_ScriptEngineData->EntityClasses.clear();
+		s_ScriptEngineData->ScriptFieldsDefaults.clear();
 
 		MonoImage* image = mono_assembly_get_image(assembly);
 		const MonoTableInfo* typeDefinitionsTable = mono_image_get_table_info(image, MONO_TABLE_TYPEDEF);
@@ -317,6 +322,11 @@ namespace Engine
 			Ref<ScriptClass> scriptClass = CreateRef<ScriptClass>(nameSpace, className);
 			s_ScriptEngineData->EntityClasses[fullName] = scriptClass;
 
+			// instantiate temp instance to get default values
+			MonoObject* instance = mono_object_new(s_ScriptEngineData->AppDomain, monoClass);
+			mono_runtime_object_init(instance);
+			ScriptFieldMap scriptDefaultMap;
+
 			// get class fields
 			int fieldCount = mono_class_num_fields(monoClass);
 			ENGINE_CORE_TRACE("{} has {} fields:", className, fieldCount);
@@ -333,8 +343,29 @@ namespace Engine
 				if (scriptField.IsPublic()) // tracking only public fields for now, want others for debug later
 				{
 					scriptClass->m_ScriptFields[fieldName] = scriptField;
+
+					// get default field value
+					ScriptFieldInstance& fieldInstance = scriptDefaultMap[fieldName];
+					fieldInstance.Field = scriptField;
+
+					uint8_t buffer[64];
+					memset(buffer, 0, sizeof(buffer));
+
+					mono_field_get_value(instance, field, buffer);
+
+					if (fieldType == ScriptFieldType::String)
+					{
+						std::string value = ScriptEngine::MonoStringToUTF8(*(MonoString**)buffer);
+						fieldInstance.SetValue(value);
+					}
+					else
+					{
+						memcpy(fieldInstance.m_Buffer, buffer, sizeof(fieldInstance.m_Buffer));
+					}
 				}
 			}
+			
+			s_ScriptEngineData->ScriptFieldsDefaults[fullName] = scriptDefaultMap;
 		}
 	}
 
@@ -366,6 +397,14 @@ namespace Engine
 		ENGINE_CORE_ASSERT(entity, "Entity doesn't exists!");
 
 		return s_ScriptEngineData->EntityScriptFields[entity.GetUUID()];
+	}
+
+	ScriptFieldMap ScriptEngine::GetDefaultScriptFieldMap(const std::string& scriptName)
+	{
+		if (!EntityClassExists(scriptName))
+			return {};
+
+		return s_ScriptEngineData->ScriptFieldsDefaults.at(scriptName);
 	}
 
 	Scene* ScriptEngine::GetSceneContext()

--- a/GameEngine/src/Engine/Scripting/ScriptEngine.cpp
+++ b/GameEngine/src/Engine/Scripting/ScriptEngine.cpp
@@ -448,10 +448,12 @@ namespace Engine
 					{
 						instance->SetFieldValueInternal(name, ScriptEngine::StringToMonoString(*(std::string*)fieldInstance.m_Buffer));
 					}
-					else if (fieldInstance.Field.Type == ScriptFieldType::Char)
-					{
-						instance->SetFieldValueInternal(name, &fieldInstance.m_Buffer[sizeof(char*)]);
-					}
+					//else if (fieldInstance.Field.Type == ScriptFieldType::Char)
+					//{
+					//	std::string& buffer = *(std::string*)fieldInstance.m_Buffer;
+					//	const char* charBuffer = buffer.c_str();
+					//	instance->SetFieldValueInternal(name, charBuffer);
+					//}
 					else
 					{
 						instance->SetFieldValueInternal(name, fieldInstance.m_Buffer);

--- a/GameEngine/src/Engine/Scripting/ScriptEngine.h
+++ b/GameEngine/src/Engine/Scripting/ScriptEngine.h
@@ -135,6 +135,7 @@ namespace Engine
 
 		static std::unordered_map<std::string, Ref<ScriptClass>> GetEntityClasses();
 		static ScriptFieldMap& GetScriptFieldMap(Entity entity);
+		static ScriptFieldMap GetDefaultScriptFieldMap(const std::string& scriptName);
 		static Scene* GetSceneContext();
 
 		static MonoAssembly* GetCoreAssembly();

--- a/GameEngine/src/Engine/Scripting/ScriptEngine.h
+++ b/GameEngine/src/Engine/Scripting/ScriptEngine.h
@@ -17,6 +17,7 @@ extern "C"
 }
 
 typedef void(*OnCreate) (MonoObject* obj, MonoObject** exp);
+typedef void(*OnStart) (MonoObject* obj, MonoObject** exp);
 typedef void(*OnDestroy) (MonoObject* obj, MonoObject** exp);
 typedef void(*OnUpdate) (MonoObject* obj, float* ts, MonoObject** exp);
 typedef void(*OnLateUpdate) (MonoObject* obj, float* ts, MonoObject** exp);
@@ -144,6 +145,7 @@ namespace Engine
 		static void DeleteEntityInstance(Ref<ScriptInstance> instance, Entity entity);
 
 		static void OnCreateEntity(Entity entity);
+		static void OnStartEntity(Entity entity);
 		static void OnDestroyEntity(Entity entity);
 		static void OnUpdateEntity(Entity entity, Timestep ts);
 		static void OnLateUpdateEntity(Entity entity, Timestep ts);
@@ -227,6 +229,7 @@ namespace Engine
 		}
 
 		void InvokeOnCreate();
+		void InvokeOnStart();
 		void InvokeOnDestroy();
 		void InvokeOnUpdate(float ts);
 		void InvokeOnLateUpdate(float ts);
@@ -244,6 +247,7 @@ namespace Engine
 
 		MonoMethod* m_Constructor = nullptr;
 		OnCreate OnCreateThunk = nullptr;
+		OnStart OnStartThunk = nullptr;
 		OnDestroy OnDestroyThunk = nullptr;
 		OnUpdate OnUpdateThunk = nullptr;
 		OnLateUpdate OnLateUpdateThunk = nullptr;

--- a/GameEngine/src/Engine/Scripting/ScriptEngine.h
+++ b/GameEngine/src/Engine/Scripting/ScriptEngine.h
@@ -213,12 +213,6 @@ namespace Engine
 			return ScriptEngine::MonoStringToUTF8(*(MonoString**)s_FieldValueBuffer);
 		}
 
-		template<>
-		char GetFieldValue(const std::string& name)
-		{
-			return *GetFieldValue<std::string>(name).c_str();
-		}
-
 		template<typename T>
 		void SetFieldValue(const std::string& name, T* value)
 		{

--- a/GameEngine/src/Engine/Scripting/ScriptEngine.h
+++ b/GameEngine/src/Engine/Scripting/ScriptEngine.h
@@ -19,6 +19,7 @@ extern "C"
 typedef void(*OnCreate) (MonoObject* obj, MonoObject** exp);
 typedef void(*OnDestroy) (MonoObject* obj, MonoObject** exp);
 typedef void(*OnUpdate) (MonoObject* obj, float* ts, MonoObject** exp);
+typedef void(*OnLateUpdate) (MonoObject* obj, float* ts, MonoObject** exp);
 
 // Created with help from this guide (Mono Embedding for Game Engines): https://peter1745.github.io/introduction.html
 
@@ -145,6 +146,7 @@ namespace Engine
 		static void OnCreateEntity(Entity entity);
 		static void OnDestroyEntity(Entity entity);
 		static void OnUpdateEntity(Entity entity, Timestep ts);
+		static void OnLateUpdateEntity(Entity entity, Timestep ts);
 
 		static bool EntityInstanceExists(Entity& entity);
 		static Ref<ScriptInstance> GetEntityInstance(Entity entity);
@@ -227,6 +229,7 @@ namespace Engine
 		void InvokeOnCreate();
 		void InvokeOnDestroy();
 		void InvokeOnUpdate(float ts);
+		void InvokeOnLateUpdate(float ts);
 
 		MonoObject* GetMonoObject() { return m_Instance; }
 
@@ -243,6 +246,7 @@ namespace Engine
 		OnCreate OnCreateThunk = nullptr;
 		OnDestroy OnDestroyThunk = nullptr;
 		OnUpdate OnUpdateThunk = nullptr;
+		OnLateUpdate OnLateUpdateThunk = nullptr;
 
 		inline static char s_FieldValueBuffer[64];
 

--- a/GameEngine/src/Engine/Scripting/ScriptEngine.h
+++ b/GameEngine/src/Engine/Scripting/ScriptEngine.h
@@ -31,8 +31,8 @@ namespace Engine
 		None = -1,
 		Float, Double,
 		Bool, Char, String,
-		Byte, Short, Int, Long,
-		UByte, UShort, UInt, ULong,
+		SByte, Short, Int, Long,
+		Byte, UShort, UInt, ULong,
 		Vector2, Vector3, Vector4,
 		Entity
 	};
@@ -84,7 +84,7 @@ namespace Engine
 		}
 
 	private:
-		char m_Buffer[64];
+		uint8_t m_Buffer[64];
 
 		friend class ScriptEngine;
 		friend class ScriptInstance;
@@ -158,6 +158,7 @@ namespace Engine
 		static uint8_t GetPropertyAccessbility(MonoProperty* property);
 
 		static void HandleMonoException(MonoObject* ptrExObject);
+		static MonoString* CharToMonoString(char& charString);
 		static MonoString* StringToMonoString(const std::string& string);
 		static std::string MonoStringToUTF8(MonoString* monoString);
 	
@@ -210,6 +211,12 @@ namespace Engine
 			}
 
 			return ScriptEngine::MonoStringToUTF8(*(MonoString**)s_FieldValueBuffer);
+		}
+
+		template<>
+		char GetFieldValue(const std::string& name)
+		{
+			return *GetFieldValue<std::string>(name).c_str();
 		}
 
 		template<typename T>
@@ -270,11 +277,11 @@ namespace Engine
 			case ScriptFieldType::Bool:		return "Bool";
 			case ScriptFieldType::Char:		return "Char";
 			case ScriptFieldType::String:	return "String";
-			case ScriptFieldType::Byte:		return "Byte";
+			case ScriptFieldType::SByte:	return "SByte";
 			case ScriptFieldType::Short:	return "Short";
 			case ScriptFieldType::Int:		return "Int";
 			case ScriptFieldType::Long:		return "Long";
-			case ScriptFieldType::UByte:	return "UByte";
+			case ScriptFieldType::Byte:		return "Byte";
 			case ScriptFieldType::UShort:	return "UShort";
 			case ScriptFieldType::UInt:		return "UInt";
 			case ScriptFieldType::ULong:	return "ULong";
@@ -295,11 +302,11 @@ namespace Engine
 			if (fieldType == "Bool")	return ScriptFieldType::Bool;
 			if (fieldType == "Char")	return ScriptFieldType::Char;
 			if (fieldType == "String")	return ScriptFieldType::String;
-			if (fieldType == "Byte")	return ScriptFieldType::Byte;
+			if (fieldType == "SByte")	return ScriptFieldType::SByte;
 			if (fieldType == "Short")	return ScriptFieldType::Short;
 			if (fieldType == "Int")		return ScriptFieldType::Int;
 			if (fieldType == "Long")	return ScriptFieldType::Long;
-			if (fieldType == "UByte")	return ScriptFieldType::UByte;
+			if (fieldType == "Byte")	return ScriptFieldType::Byte;
 			if (fieldType == "UShort")	return ScriptFieldType::UShort;
 			if (fieldType == "UInt")	return ScriptFieldType::UInt;
 			if (fieldType == "ULong")	return ScriptFieldType::ULong;

--- a/GameEngine/src/Engine/Scripting/ScriptGlue.cpp
+++ b/GameEngine/src/Engine/Scripting/ScriptGlue.cpp
@@ -85,6 +85,7 @@ namespace InternalCalls
 		ENGINE_ADD_INTERNAL_CALL(SpriteRendererComponent_GetTiling);
 		ENGINE_ADD_INTERNAL_CALL(SpriteRendererComponent_SetTiling);
 
+		ENGINE_ADD_INTERNAL_CALL(Rigidbody2DComponent_GetLinearVelocity);
 		ENGINE_ADD_INTERNAL_CALL(Rigidbody2DComponent_ApplyLinearImpulse);
 		ENGINE_ADD_INTERNAL_CALL(Rigidbody2DComponent_ApplyLinearImpulseToCenter);
 	}
@@ -381,6 +382,14 @@ namespace InternalCalls
 #pragma endregion SpriteRendererComponent
 
 #pragma region Rigidbody2DComponent
+
+	void ScriptGlue::Rigidbody2DComponent_GetLinearVelocity(Engine::UUID entityID, glm::vec2* velocity)
+	{
+		Engine::Entity entity = GetEntityFromScene(entityID);
+		b2Body* body = (b2Body*)entity.GetComponent<Engine::Rigidbody2DComponent>().RuntimeBody;
+		const b2Vec2& rb2dVelocity = body->GetLinearVelocity();
+		*velocity = { rb2dVelocity.x, rb2dVelocity.y };
+	}
 
 	void ScriptGlue::Rigidbody2DComponent_ApplyLinearImpulse(Engine::UUID entityID, glm::vec2& impulse, glm::vec2& worldPosition, bool wake)
 	{

--- a/GameEngine/src/Engine/Scripting/ScriptGlue.h
+++ b/GameEngine/src/Engine/Scripting/ScriptGlue.h
@@ -111,10 +111,12 @@ namespace InternalCalls
 
 #pragma region Rigidbody2DComponent
 
+		static void Rigidbody2DComponent_GetLinearVelocity(Engine::UUID entityID, glm::vec2* velocity);
 		static void Rigidbody2DComponent_ApplyLinearImpulse(Engine::UUID entityID, glm::vec2& impulse, glm::vec2& worldPosition, bool wake);
 		static void Rigidbody2DComponent_ApplyLinearImpulseToCenter(Engine::UUID entityID, glm::vec2& impulse, bool wake);
 
 #pragma endregion Rigidbody2DComponent
 	};
+
 }
 


### PR DESCRIPTION
- Added new Entity Script method OnStart which now happens after all Script entities have been created at the start of the runtime
- Added new Entity Script method OnLateUpdate which allows for scripts to have update functionality happen after script update and physics update (great for cameras that are tracking moving transforms)
- Fixed Crash when Destroying Entity in the scene hierarchy
- Fixed Duplicate Entity Shortcut
- Added Delete Entity Shortcut
- Added Script Core Math Function Clamp
- Added Editor controls for support script field types (except Entities)
- Made picking Script Class a drop-down of valid entity classes in Script Component vs typing the exact class name
- Newly added script components now have their script field values default to the values in the script (if provided)
- When reloading script assembly, the open scene now reloads (TODO - prompt user to save before reloading scene + make sure serialized values take priority of script defaults)